### PR TITLE
:bug: navigation: fix backUntil

### DIFF
--- a/lib/get_navigation/src/routes/get_router_delegate.dart
+++ b/lib/get_navigation/src/routes/get_router_delegate.dart
@@ -634,7 +634,7 @@ class GetDelegate<T> extends RouterDelegate<RouteDecoder<T>>
 
   @override
   void backUntil(bool Function(GetPage) predicate) {
-    while (_activePages.length <= 1 && !predicate(_activePages.last.route!)) {
+    while (_activePages.isNotEmpty && !predicate(_activePages.last.route!)) {
       _popWithResult();
     }
 


### PR DESCRIPTION
Motivation: `Get.backUntil` or, more specific,  `GetRouterDelegate.backUntil` checks if the number of `_activePages.length <= 1`, which does not make sense. `GetRouterDelegate.offUntil`, which has similar semantics, tests if `_activePages.isNotEmpty`. So in order to make `backUntil` work as expected and to be consistent with `offUntil` I propose the following change.
